### PR TITLE
Fix shared lib being static in example

### DIFF
--- a/samples/recipe.txt
+++ b/samples/recipe.txt
@@ -32,7 +32,7 @@
 |SHARED_LIBS lib
 
 # List many shared libraries
-|STATIC_LIBS /additional/library/paths/
+|SHARED_LIBS /additional/library/paths/
     lib1
     lib2
 


### PR DESCRIPTION
In your example a SHARED_LIBS declaration is accidentally a STATIC_LIBS declaration